### PR TITLE
ConfigForASystemTimeOf: SystemTime.Today was being incorrectly set

### DIFF
--- a/Quarks/Machine.Fakes/ConfigForASystemTimeOf.cs
+++ b/Quarks/Machine.Fakes/ConfigForASystemTimeOf.cs
@@ -19,7 +19,7 @@ namespace Quarks.Machine.Fakes
 		{
 			SystemTime.Now = _fakeTime;
 			SystemTime.UtcNow = _fakeTime;
-			SystemTime.Today = _fakeTime;
+			SystemTime.Today = _fakeTime.Date;
 		};
 
 		OnCleanup after = ctx => SystemTime.Reset();

--- a/Quarks/Machine.Fakes/ConfigForASystemTimeOf.nuspec
+++ b/Quarks/Machine.Fakes/ConfigForASystemTimeOf.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
 	<metadata>
 		<id>Quarks.Machine.Fakes.ConfigForASystemTimeOf</id>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 		<authors>Shayne van Asperen</authors>
 		<owners>Shayne van Asperen</owners>
 		<licenseUrl>https://github.com/shaynevanasperen/Quarks/blob/master/LICENSE</licenseUrl>


### PR DESCRIPTION
ConfigForASystemTimeOf: SystemTime.Today was being incorrectly set to _fakeTime rather than _fakeTime.Date